### PR TITLE
Add ability to delete user from Service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,15 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group 'com.messente.verigator'
-version '1.0'
+version '1.1'
 
 sourceCompatibility = 1.8
+
+jar {
+    manifest {
+        attributes 'Implementation-Version': version
+    }
+}
 
 bintray {
     user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip

--- a/src/main/java/com/messente/verigator/BuildVersion.java
+++ b/src/main/java/com/messente/verigator/BuildVersion.java
@@ -1,0 +1,7 @@
+package com.messente.verigator;
+
+public class BuildVersion {
+    public static String getBuildVersion() {
+        return BuildVersion.class.getPackage().getImplementationVersion();
+    }
+}

--- a/src/main/java/com/messente/verigator/Http.java
+++ b/src/main/java/com/messente/verigator/Http.java
@@ -65,6 +65,8 @@ class Http {
             log.debug(requestMethod);
             con.setRequestMethod(requestMethod);
             con.setRequestProperty("X-Service-Auth", username + ":" + password);
+            con.setRequestProperty("Accept", "application/json");
+            con.setRequestProperty("User-Agent", "verigator-java-" + BuildVersion.getBuildVersion());
             if (headers != null) {
                 for (Map.Entry<String, String> entry : headers.entrySet()) {
                     con.setRequestProperty(entry.getKey(), entry.getValue());

--- a/src/main/java/com/messente/verigator/Service.java
+++ b/src/main/java/com/messente/verigator/Service.java
@@ -49,7 +49,6 @@ public class Service {
 
     /**
      * Return the UNIX timestamp indicating when the service was created
-     * @return
      */
     public String getCtime() {
         return ctime;
@@ -57,7 +56,6 @@ public class Service {
 
     /**
      * Return the name of the service in Verigator
-     * @return
      */
     public String getName() {
         return name;

--- a/src/main/java/com/messente/verigator/User.java
+++ b/src/main/java/com/messente/verigator/User.java
@@ -25,7 +25,6 @@ public class User {
 
     /**
      * Returns the UNIX time indicating when the user was created
-     * @return
      */
     public String getCtime() {
         return ctime;
@@ -33,7 +32,6 @@ public class User {
 
     /**
      * Returns the username of the Verigator
-     * @return
      */
     public String getUsername() {
         return username;

--- a/src/main/java/com/messente/verigator/User.java
+++ b/src/main/java/com/messente/verigator/User.java
@@ -5,10 +5,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.messente.verigator.exceptions.Helpers;
 import com.messente.verigator.exceptions.*;
-import com.messente.verigator.serializers.AuthenticationRequest;
-import com.messente.verigator.serializers.AuthenticationResponse;
-import com.messente.verigator.serializers.VerificationRequest;
-import com.messente.verigator.serializers.VerificationResponse;
+import com.messente.verigator.serializers.*;
 
 /**
  * Represents a User in Verigator API
@@ -24,6 +21,7 @@ public class User {
 
     private Service service;
     private static final String AUTH_ENDPOINT = "service/service/%s/users/%s/auth";
+    private static final String USERS_ENDPOINT = "service/service/%s/users/%s";
 
     /**
      * Returns the UNIX time indicating when the user was created
@@ -128,6 +126,19 @@ public class User {
         );
         Helpers.validateCommon(resp, 200);
         return new Gson().fromJson(resp.getResponseBody(), VerificationResponse.class);
+    }
+    /**
+     * Deletes given user from service
+     * @throws ResourceForbiddenException if you do not have access to the specified service
+     * @throws WrongCredentialsException if you have specified the incorrect credentials
+     * @throws VerigatorInternalError if a server-side error occurs
+     * @throws VerigatorException if there is a connection error
+     */
+    public void delete() throws VerigatorException {
+        VerigatorResponse resp = service.getHttp().performDelete(
+            String.format(USERS_ENDPOINT, service.getServiceId(), id)
+        );
+        Helpers.validateCommon(resp, 202);
     }
 
     public void setService(Service service) {

--- a/src/main/java/com/messente/verigator/serializers/VerificationFlowExample.java
+++ b/src/main/java/com/messente/verigator/serializers/VerificationFlowExample.java
@@ -1,0 +1,4 @@
+package com.messente.verigator.serializers;
+
+public class VerificationFlowExample {
+}

--- a/src/test/java/com/messente/verigator/ServiceTests.java
+++ b/src/test/java/com/messente/verigator/ServiceTests.java
@@ -24,7 +24,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("GET").
                                 withPath("/v1/service/service/" + successId + "/users").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response(
@@ -60,7 +60,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("GET").
                                 withPath("/v1/service/service/" + wrongId + "/users").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response().
@@ -81,7 +81,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("GET").
                                 withPath("/v1/service/service/" + successId + "/users").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("{\"total\": 0, \"users\": []}").
@@ -104,7 +104,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST").
                                 withPath("/v1/service/service/" + successId + "/users").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("{\"ctime\": \"fake-ctime-1\", id:\"mock-id-1\", \"id_in_service\": \"fake-id-in-service-1\"}"
@@ -132,7 +132,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST").
                                 withPath("/v1/service/service/" + successId + "/users").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("").
@@ -156,7 +156,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("GET").
                                 withPath("/v1/service/service/" + successId + "/users").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("{\"total\": 0, \"users\": []}").
@@ -179,7 +179,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST").
                                 withPath("/v1/service/service/" + serviceId + "/users").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response().
@@ -202,7 +202,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST").
                                 withPath("/v1/service/service/" + serviceId + "/users").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response().
@@ -222,7 +222,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("DELETE").
                                 withPath("/v1/service/service/" + successId).
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response().
@@ -244,7 +244,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("DELETE").
                                 withPath("/v1/service/service/" + serviceId).
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response().
@@ -266,7 +266,7 @@ public class ServiceTests extends VerigatorTestCase {
                         request().
                                 withMethod("DELETE").
                                 withPath("/v1/service/service/" + serviceId).
-                                withHeaders(getExpectAuthHeader("wrong-user", "wrong-pass"))
+                                withHeaders(getAuthHeader("wrong-user", "wrong-pass"))
                 )
                 .respond(
                         response().

--- a/src/test/java/com/messente/verigator/UserTests.java
+++ b/src/test/java/com/messente/verigator/UserTests.java
@@ -30,7 +30,7 @@ public class UserTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST").
                                 withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId + "/auth").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("{\"method\": \"sms\"}").
@@ -54,7 +54,7 @@ public class UserTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST").
                                 withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId + "/auth").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("{\"method\": \"totp\", \"auth_id\": null}").
@@ -80,7 +80,7 @@ public class UserTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST").
                                 withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId + "/auth").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response().
@@ -99,7 +99,7 @@ public class UserTests extends VerigatorTestCase {
                     request().
                         withMethod("POST").
                         withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId + "/auth").
-                        withHeaders(getExpectAuthHeader())
+                        withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("").
@@ -117,7 +117,7 @@ public class UserTests extends VerigatorTestCase {
                         request().
                                 withMethod("PUT").
                                 withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId + "/auth").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("{\"method\": \"totp\", \"verified\": true}").
@@ -138,7 +138,7 @@ public class UserTests extends VerigatorTestCase {
                         request().
                                 withMethod("PUT").
                                 withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId + "/auth").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("{\"method\": \"totp\", \"verified\": false}").
@@ -160,7 +160,7 @@ public class UserTests extends VerigatorTestCase {
                         request().
                                 withMethod("PUT").
                                 withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId + "/auth").
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("").
@@ -181,7 +181,7 @@ public class UserTests extends VerigatorTestCase {
                         request().
                                 withMethod("DELETE").
                                 withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId).
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("").
@@ -199,7 +199,7 @@ public class UserTests extends VerigatorTestCase {
                         request().
                                 withMethod("DELETE").
                                 withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId).
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("").
@@ -221,7 +221,7 @@ public class UserTests extends VerigatorTestCase {
                         request().
                                 withMethod("DELETE").
                                 withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId).
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getCommonHeaders())
                 )
                 .respond(
                         response("").

--- a/src/test/java/com/messente/verigator/UserTests.java
+++ b/src/test/java/com/messente/verigator/UserTests.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+
 import static org.mockserver.model.HttpRequest.request;
 
 import static org.junit.Assert.assertEquals;
@@ -168,5 +169,66 @@ public class UserTests extends VerigatorTestCase {
         Service service = new Service(testServiceId, getVerigatorTestClient());
         User user = new User(service, testUserId);
         user.verifyPin(mockPin);
+    }
+
+    @Rule
+    public ExpectedException testDeleteForbidden = ExpectedException.none();
+    @Test
+    public void testDeleteForbidden() throws VerigatorException {
+        testDeleteForbidden.expect(ResourceForbiddenException.class);
+        mockServer.
+                when(
+                        request().
+                                withMethod("DELETE").
+                                withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId).
+                                withHeaders(getExpectAuthHeader())
+                )
+                .respond(
+                        response("").
+                                withStatusCode(403)
+                );
+        Service service = new Service(testServiceId, getVerigatorTestClient());
+        User user = new User(service, testUserId);
+        user.delete();
+    }
+
+    @Test
+    public void testDeleteSuccess() throws VerigatorException {
+        mockServer.
+                when(
+                        request().
+                                withMethod("DELETE").
+                                withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId).
+                                withHeaders(getExpectAuthHeader())
+                )
+                .respond(
+                        response("").
+                                withStatusCode(202)
+                );
+        Service service = new Service(testServiceId, getVerigatorTestClient());
+        User user = new User(service, testUserId);
+        user.delete();
+    }
+
+    @Rule
+    public ExpectedException deleteNotFound = ExpectedException.none();
+
+    @Test
+    public void testDeleteNotFound() throws VerigatorException {
+        deleteNotFound.expect(NoSuchResourceException.class);
+        mockServer.
+                when(
+                        request().
+                                withMethod("DELETE").
+                                withPath("/v1/service/service/" + testServiceId + "/users/" + testUserId).
+                                withHeaders(getExpectAuthHeader())
+                )
+                .respond(
+                        response("").
+                                withStatusCode(404)
+                );
+        Service service = new Service(testServiceId, getVerigatorTestClient());
+        User user = new User(service, testUserId);
+        user.delete();
     }
 }

--- a/src/test/java/com/messente/verigator/VerigatorTestCase.java
+++ b/src/test/java/com/messente/verigator/VerigatorTestCase.java
@@ -30,12 +30,24 @@ public class VerigatorTestCase {
         proxy = startClientAndProxy(1090);
     }
 
-    protected Header getExpectAuthHeader() {
-        return getExpectAuthHeader(testUser, testPassword);
+    protected Header getAuthHeader() {
+        return getAuthHeader(testUser, testPassword);
     }
 
-    protected Header getExpectAuthHeader(String useername, String password) {
-        return new Header("X-Service-Auth", useername+ ":" + password);
+    protected Header getAcceptHeader() {
+        return new Header("Accept", "application/json");
+    }
+
+    protected Header getUserAgentHeader() {
+        return new Header("User-Agent", "verigator-java-" + BuildVersion.getBuildVersion());
+    }
+
+    protected Header getAuthHeader(String username, String password) {
+        return new Header("X-Service-Auth", username+ ":" + password);
+    }
+
+    protected Header[] getCommonHeaders() {
+        return new Header[] { getAcceptHeader(), getAuthHeader(), getUserAgentHeader()};
     }
 
     @After

--- a/src/test/java/com/messente/verigator/VerigatorTests.java
+++ b/src/test/java/com/messente/verigator/VerigatorTests.java
@@ -1,3 +1,4 @@
+
 package com.messente.verigator;
 
 import com.messente.verigator.exceptions.*;
@@ -20,7 +21,7 @@ public class VerigatorTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST")
                                 .withPath("/v1/service/service")
-                                .withHeaders(getExpectAuthHeader())
+                                .withHeaders(getAuthHeader(), getAcceptHeader(), getUserAgentHeader())
                 )
                 .respond(
                         response().
@@ -46,13 +47,12 @@ public class VerigatorTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST")
                                 .withPath("/v1/service/service")
-                                .withHeaders(getExpectAuthHeader())
+                                .withHeaders(getAuthHeader())
                 )
                 .respond(
                         response().
                                 withStatusCode(409).
-                                withHeaders(jsonHeader).
-                                withBody("wew")
+                                withHeaders(jsonHeader)
 
                 );
         Verigator verigator = getVerigatorTestClient();
@@ -68,7 +68,7 @@ public class VerigatorTests extends VerigatorTestCase {
                         request().
                                 withMethod("POST")
                                 .withPath("/v1/service/service")
-                                .withHeaders(getExpectAuthHeader("wrong_user", "wrong_pass"))
+                                .withHeaders(getAuthHeader("wrong_user", "wrong_pass"))
                 )
                 .respond(
                         response().
@@ -89,7 +89,7 @@ public class VerigatorTests extends VerigatorTestCase {
                         request().
                                 withMethod("GET").
                                 withPath("/v1/service/service/" + wrongServiceId).
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getAuthHeader())
                 )
                 .respond(
                         response().
@@ -110,7 +110,7 @@ public class VerigatorTests extends VerigatorTestCase {
                         request().
                                 withMethod("GET").
                                 withPath("/v1/service/service/" + forbiddenServiceId).
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getAuthHeader())
                 )
                 .respond(
                         response().
@@ -130,7 +130,7 @@ public class VerigatorTests extends VerigatorTestCase {
                         request().
                                 withMethod("GET").
                                 withPath("/v1/service/service/" + successId).
-                                withHeaders(getExpectAuthHeader())
+                                withHeaders(getAuthHeader())
                 )
                 .respond(
                         response(


### PR DESCRIPTION
This is my first break week task:  https://3.basecamp.com/3528107/buckets/1546162/todos/873827849
The Python version already included this functionality, so no changes there.

The documentation was also updated:
Currently invisible link which will made visible once this PR has been approved: http://messente2.voog.com/documentation/verification-api/deleting-users

As part of this task I also handled:

- https://github.com/messente/verigator-java/issues/2
- https://github.com/messente/verigator-java/issues/1

Also, briefly looked into another break week task briefly, which I think should solve the question of Java versioning. This was also included here, the version specified in `build.gradle` is used in the User-Agent (the Java code reads it from the Jar manfiest).

1.1 version JAR will be uploaded to Bintray after PR review.

Tested in live environment.